### PR TITLE
Update scipy API usage for py 3.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ CLASSIFIERS = (
 INSTALL_REQUIRES = (
     'setuptools',
     'numpy',
-    'scipy',
+    'scipy>=1.14',
     'srxraylib',
     'oasys-srwpy',
     'pySRU',

--- a/xoppylib/sources/srundplug.py
+++ b/xoppylib/sources/srundplug.py
@@ -1565,8 +1565,8 @@ def calc3d_srw_step_by_step(bl,photonEnergyMin=3000.0,photonEnergyMax=55000.0,ph
                           zero_emittance=zero_emittance,srw_max_harmonic_number=None,fileName=None,fileAppend=False)
 
         # cs = numpy.cumsum(f)
-        from scipy.integrate import cumtrapz
-        cs = cumtrapz(f,e,initial=0)
+        from scipy.integrate import cumulative_trapezoid
+        cs = cumulative_trapezoid(f,e,initial=0)
 
         cs /= cs[-1]
 

--- a/xoppylib/sources/xoppy_bm_wiggler.py
+++ b/xoppylib/sources/xoppy_bm_wiggler.py
@@ -6,7 +6,7 @@ from srxraylib.sources import srfunc
 from srxraylib.util.h5_simple_writer import H5SimpleWriter
 
 from scipy.interpolate import interp1d
-from scipy.integrate import cumtrapz
+from scipy.integrate import cumulative_trapezoid
 import scipy.constants as codata
 
 from xoppylib.fit_gaussian2d import fit_gaussian2d, info_params, twoD_Gaussian
@@ -414,7 +414,7 @@ def xoppy_calc_wiggler_radiation(
 
 
     try:
-        cumulated_power = cumtrapz(power, energy, initial=0)
+        cumulated_power = cumulative_trapezoid(power, energy, initial=0)
     except:
         cumulated_power = 0.0
     print("Power from integral of spectrum (trapezoid rule): %8.3f W" % (cumulated_power[-1]))


### PR DESCRIPTION
Related to #7 

This is needed since scipy<1.14 is not build on python 3.13